### PR TITLE
Update Hushboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,138 @@
-__pycache__
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE README.md
+include hushboard/icons/*.svg

--- a/README.md
+++ b/README.md
@@ -11,4 +11,46 @@ Mute your microphone while typing, for Ubuntu. Install from [kryogenix.org/code/
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/hushboard)
 
-(for techies: run as `python3 -m hushboard`)
+## Installation
+
+We recommend you install Hushboard through the snap store (see link above)
+
+```bash
+sudo snap install hushboard
+```
+
+If you're on Arch (btw), there's also an AUR package available for installation:
+
+```bash
+yay -S hushboard-git
+```
+
+## Manual installation
+
+Manual installation or just running the application without installing are
+described here.
+
+### Dependencies
+
+Ensure the following python dependencies are installed:
+
+* `pycairo`
+* `PyGObject`
+* `six`
+* `xlib`
+
+### Running the application
+
+Simply running the application:
+
+```console
+python3 -m hushboard
+```
+
+### Installing Hushboard
+
+Installing Hushboard to your system:
+
+```console
+python3 setup.py install
+```

--- a/hushboard/__main__.py
+++ b/hushboard/__main__.py
@@ -224,9 +224,13 @@ class HushboardIndicator(GObject.GObject):
         Gtk.main()
 
 
-if __name__ == "__main__":
+def main():
     try:
         HushboardIndicator().run()
     except KeyboardInterrupt:
         # unmute if interrupted by ^c because the ^c keypress will have muted!
         PulseHandler(None).unmute()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from setuptools import setup
+from setuptools import find_packages
+
+
+def get_long_description() -> str:
+    with open("README.md", "r") as file:
+        return file.read()
+
+
+setup(
+    name="hushboard",
+    version="0.0.1",
+    description="Mute your mic while you're typing.",
+    long_description=get_long_description(),
+    long_description_content_type="text/markdown",
+    author="Stuart Langridge",
+    author_email="sil@kryogenix.org",
+    license="MIT",
+    url="https://github.com/stuartlangridge/hushboard",
+    packages=find_packages(),
+    install_requires=[],
+    python_requires=">=3.6.12",
+    entry_points={
+        "console_scripts": ["hushboard=hushboard.__main__:main"],
+    },
+    include_package_data=True,
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: End Users/Desktop",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: Unix",
+    ],
+    extras_require={},
+)


### PR DESCRIPTION
Modify `__main__.py`:
  - Put main into a function to allow entrypoint via setup.py

Add setup.py
  - Allow for an easy installation

Update README
  - Add installation instructions for manual installation
  - Add installation instructions for Arch

Add MANIFEST.in
  - Describe which sources to include

Signed-off-by: Jeffrey Bouter <jb@warpnet.nl>